### PR TITLE
switch from HostPath to PersistentVolumeClaim

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
@@ -118,11 +118,11 @@ public class KubernetesBackend extends AbstractContainerBackend {
 		VolumeMount[] volumeMounts = new VolumeMount[volumeStrings.length];
 		for (int i = 0; i < volumeStrings.length; i++) {
 			String[] volume = volumeStrings[i].split(":");
-			String hostSource = volume[0];
+			String claimName = volume[0];
 			String containerDest = volume[1];
 			String name = "shinyproxy-volume-" + i;
 			volumes[i] = new VolumeBuilder()
-					.withNewHostPath(hostSource)
+					.withNewPersistentVolumeClaim(claimName,true)
 					.withName(name)
 					.build();
 			volumeMounts[i] = new VolumeMountBuilder()


### PR DESCRIPTION
Following issue #5, I think that supporting PersistentVolumeClaim should be pretty easy.
This commit/PR is just a proof of concept for now.
I was able to confirm that it was working by using the same "container-volume" syntax in application.yml:
`container-volumes: ["claim_name:/path_in_container"]`