### PR TITLE
PoC kubernetes backend add ressource (cpu/mem) requests and limits

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
@@ -50,6 +50,8 @@ import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.QuantityBuilder;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.SecurityContext;
 import io.fabric8.kubernetes.api.model.SecurityContextBuilder;
 import io.fabric8.kubernetes.api.model.Service;
@@ -145,12 +147,19 @@ public class KubernetesBackend extends AbstractContainerBackend {
 		List<ContainerPort> containerPorts = spec.getPortMapping().values().stream()
 				.map(p -> new ContainerPortBuilder().withContainerPort(p).build())
 				.collect(Collectors.toList());
+
+		ResourceRequirementsBuilder resourceRequirementsBuilder = new ResourceRequirementsBuilder();
+		resourceRequirementsBuilder.addToRequests("memory", new QuantityBuilder().withAmount("1500Mi").build());
+		resourceRequirementsBuilder.addToRequests("cpu", new QuantityBuilder().withAmount("1").build());
+		resourceRequirementsBuilder.addToLimits("memory", new QuantityBuilder().withAmount("4Gi").build());
+		resourceRequirementsBuilder.addToLimits("cpu", new QuantityBuilder().withAmount("2").build());
 		
 		ContainerBuilder containerBuilder = new ContainerBuilder()
 				.withImage(spec.getImage())
 				.withCommand(spec.getCmd())
 				.withName("sp-container-" + container.getId())
 				.withPorts(containerPorts)
+				.withResources(resourceRequirementsBuilder.build())
 				.withVolumeMounts(volumeMounts)
 				.withSecurityContext(security)
 				.withEnv(envVars);


### PR DESCRIPTION
The Kubernetes autoscaler bases its scaling decision on the pod cpu and memory requests.
That's why containerproxy needs a way to define the cpu and memory requirements.
This PR is a PoC for now, showing that it's quite possible using the fabric8 api.
I was able to confirm that the containers launched with this code required the appropriate levels of cpu and memory and that the autoscaler is reacting accordingly.

_Containers:
  sp-container-xxxx-xxxx-xxxx-xxxx-xxxx:
    Image:      gcr.io/xxx/docker_amelie_gui:latest
    Port:       3838/TCP
    Host Port:  0/TCP
    Command:
      R
      -e
      shiny::runApp('.', port = 3838, host = '0.0.0.0')
    Limits:
      cpu:     2
      memory:  4Gi
    Requests:
      cpu:     1
      memory:  1500Mi
    Environment:
      SHINYPROXY_USERNAME:    xxx
      SHINYPROXY_USERGROUPS:  ADMINS
    Mounts:
      /xxx from shinyproxy-volume-0 (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-xxxx (ro)_

Work to be done: decide a way the user can define these levels in the configuration file, and propagate these value to the backend class.
