### PR TITLE
influxdb now records non-ASCII usernames correctly

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/stat/impl/InfluxDBCollector.java
+++ b/src/main/java/eu/openanalytics/containerproxy/stat/impl/InfluxDBCollector.java
@@ -53,7 +53,7 @@ public class InfluxDBCollector implements IStatCollector {
 		conn.setRequestMethod("POST");
 		conn.setDoOutput(true);
 		try (DataOutputStream dos = new DataOutputStream(conn.getOutputStream())) {
-			dos.writeBytes(body);
+			dos.write(body.getBytes("UTF-8"));
 			dos.flush();
 		}
 		int responseCode = conn.getResponseCode();


### PR DESCRIPTION
If the username contains non-ASCII strings, the influxdb will record garbage characters. 

It's because the string needs to be written to UTF-8 bytes when POSTing. 

This PR fixes the bug.