### PR TITLE
add display-group field to the proxy spec

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/model/spec/ProxySpec.java
+++ b/src/main/java/eu/openanalytics/containerproxy/model/spec/ProxySpec.java
@@ -30,6 +30,7 @@ public class ProxySpec {
 	private String id;
 	private String displayName;
 	private String description;
+	private String displayGroup;
 	private String logoURL;
 	
 	private ProxyAccessControl accessControl;
@@ -58,6 +59,14 @@ public class ProxySpec {
 		this.displayName = displayName;
 	}
 
+	public String getDisplayGroup() {
+		return displayGroup;
+	}
+
+	public void setDisplayGroup(String displayGroup) {
+		this.displayGroup = displayGroup;
+	}
+	
 	public String getDescription() {
 		return description;
 	}
@@ -109,6 +118,7 @@ public class ProxySpec {
 	public void copy(ProxySpec target) {
 		target.setId(id);
 		target.setDisplayName(displayName);
+		target.setDisplayGroup(displayGroup);
 		target.setDescription(description);
 		target.setLogoURL(logoURL);
 		


### PR DESCRIPTION
Hi,

This PR will enable users to define a field `proxy.spec.displayGroup` in the application.yml, which allows the apps being grouped in the shinyproxy webpages. For example, users can build several navbar menus, each of which displays the app links of the same groups.