### PR TITLE
kubernetes-client readiness check is not able to check services.

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -246,10 +247,8 @@ public class KubernetesBackend extends AbstractContainerBackend {
 						.withPorts(servicePorts)
 						.endSpec()
 					.done();
-			
-			// Workaround: waitUntilReady appears to be buggy.
-			Retrying.retry(i -> Readiness.isReady(kubeClient.resource(startupService).fromServer().get()), 60, 1000);
-			service = kubeClient.resource(startupService).fromServer().get();
+
+			service = kubeClient.resource(startupService).waitUntilReady(30, TimeUnit.SECONDS);
 		}
 		
 		container.getParameters().put(PARAM_POD, pod);


### PR DESCRIPTION
The k8s-client can not check readiness of kind `service`: https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/internal/readiness/Readiness.java#L79

This PR is switching to `waitUntilReady`. Notice: this ignores the comment `// Workaround: waitUntilReady appears to be buggy.`. I have tested it with `waitUntilReady` on my local k8s-cluster and it works as expected.

containerproxy must use _Kubernetes_ as backend and must not be running inside the cluster (`proxy.kubernetes.internal-networking: false`) in order to reach the affected code.