### PR TITLE
Adding support for PersistentVolumeClaim

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
@@ -131,15 +131,28 @@ public class KubernetesBackend extends AbstractContainerBackend {
 			String[] volume = volumeStrings[i].split(":");
 			String hostSource = volume[0];
 			String containerDest = volume[1];
-			String name = "shinyproxy-volume-" + i;
-			volumes.add(new VolumeBuilder()
-					.withNewHostPath(hostSource, "")
-					.withName(name)
-					.build());
-			volumeMounts[i] = new VolumeMountBuilder()
-					.withMountPath(containerDest)
-					.withName(name)
-					.build();
+			String name = "shinyproxy-volume-" + i;			
+			if (hostSource.contains("/")) {
+				volumes.add(new VolumeBuilder()
+						.withNewHostPath(hostSource, "")
+						.withName(name)
+						.build());
+				volumeMounts[i] = new VolumeMountBuilder()
+						.withMountPath(containerDest)
+						.withName(name)
+						.build();
+			} else { // PersistentVolume
+				volumes.add(new VolumeBuilder()
+						.withNewPersistentVolumeClaim(hostSource, false) // readonly - false
+						.withName(name)
+						.build());
+
+				volumeMounts[i] = new VolumeMountBuilder()
+						.withMountPath(containerDest)
+						.withName(name)
+						.withReadOnly(false)
+						.build();
+			}
 		}
 
 		List<EnvVar> envVars = new ArrayList<>();


### PR DESCRIPTION
Adding support for PersistentVolumeClaim
Using the following yaml files you can mount persistent mounts on google cloud


`sp-volumeclaim.yml `
``` 
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: sp-volumeclaim
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 200Gi

``` 


`application.yml ` in shinyproxy
``` 
proxy:
  port: 8080
  authentication: simple
  admin-groups: admins
  users:
  - name: jack
    password: password
    groups: admins
  container-backend: kubernetes
  kubernetes:
    internal-networking: true
    url: http://localhost:8001
  container-log-path: ./container-logs
  specs:
  - id: atlas
    display-name:  Atlas
    container-cmd: ["R", "-e", "shiny::runApp('/srv/shiny-server/atlas', host = '0.0.0.0', port = 3838, launch.browser = FALSE, quiet = TRUE)"]
    container-image: atlas:v1.0-1
    container-volumes: ["sp-volumeclaim:/srv/shiny-server/atlas/www"]
```

