### PR TITLE
Support for load balancer and maxAuthenticationAge in SAML

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/auth/impl/saml/SAMLConfiguration.java
+++ b/src/main/java/eu/openanalytics/containerproxy/auth/impl/saml/SAMLConfiguration.java
@@ -284,7 +284,10 @@ public class SAMLConfiguration {
 
 	@Bean
 	public WebSSOProfileConsumer webSSOprofileConsumer() {
-		return new WebSSOProfileConsumerImpl();
+		WebSSOProfileConsumerImpl webSSOProfileConsumerImpl = new WebSSOProfileConsumerImpl();
+		String maxAuthAge = environment.getProperty("proxy.saml.max-auth-age");
+		if (maxAuthAge != null) webSSOProfileConsumerImpl.setMaxAuthenticationAge(Long.valueOf(maxAuthAge));
+		return webSSOProfileConsumerImpl;
 	}
 
 	@Bean


### PR DESCRIPTION
This pull request covers two issues I've come across when using SAML authentication.

First, when ShinyProxy/ContainerProxy is running behind a load balancer (or in my case a Kubernetes ingress controller) and SSL traffic is terminated at the load balancer, then authentication fails with the following error:

```
2019-10-14 09:23:05.704 ERROR 1 --- [  XNIO-2 task-2] o.o.c.b.decoding.BaseSAMLMessageDecoder  : SAML message intended destination endpoint 'https://shinyapp.host.domain.xyz/saml/SSO' did not match the recipient endpoint 'http://shinyapp.host.domain.xyz/saml/SSO'
```
The issue is fixed by using the [SAMLContextProviderLB](https://docs.spring.io/spring-security-saml/docs/2.0.x/reference/html/configuration-advanced.html#configuration-load-balancing) context provider.

The implementation exposes the following new configuration options under `proxy.saml`:
- `lb-server-name`: Server name of the load balancer. By setting this option, load balancer support is enabled.
- `lb-context-path`: Context path of the load balancer. Optional. Default value `/`.
- `lb-port-in-url`: Include server port in construction of load balancer request URL. Optional. Default value `false`.
- `lb-scheme`: Scheme of the load balancer - either http or https. Optional. Default value `https`.
- `lb-server-port`: Port of the load balancer server. Optional. Default value `443`.

Second, if the IDP issues tokens that are valid longer than 7200 seconds, then the following error can occur `CredentialsExpiredException: Authentication statement is too old to be used`.

This issue is fixed by exposing the following configuration setting:
- `proxy.saml.max-auth-age`: Maximum time (in seconds) between users authentication and processing of an authentication statement.

and setting it to a sufficiently high value.

More details and a build of the ShinyProxy jar which incorporates these changes can be found [here](https://github.com/johannestang/shinyproxy-lb).
