### PR TITLE
Add label to Kubernetes Pods with spec id.

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/kubernetes/KubernetesBackend.java
@@ -207,6 +207,7 @@ public class KubernetesBackend extends AbstractContainerBackend {
 				.withNewMetadata()
 					.withName("sp-pod-" + container.getId())
 					.addToLabels("app", container.getId())
+					.addToLabels("sp-spec-id", proxy.getSpec().getId())
 					.endMetadata();
 		
 		PodSpec podSpec = new PodSpec();


### PR DESCRIPTION
When deploying multiple Shiny apps to a Kubernetes cluster the Pods running the apps are given generic names. This makes it cumbersome to figure out which app is running in a given Pod.

This pull request adds a label to the Pods with the spec id of the app (called `sp-spec-id`). For example, if Shinyproxy has been configured with an app that has the id `shinytest` then `kubectl get all --show-labels` would return:
```
NAME                                                              READY   STATUS    RESTARTS   AGE   LABELS
pod/sp-pod-94aa06a8-f94e-4204-a476-832b7d26d1dd                   1/1     Running   0          81s   app=94aa06a8-f94e-4204-a476-832b7d26d1dd,sp-spec-id=shinytest
```