### PR TITLE
Set proxy client's max queue size

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/util/ProxyMappingManager.java
+++ b/src/main/java/eu/openanalytics/containerproxy/util/ProxyMappingManager.java
@@ -88,6 +88,7 @@ public class ProxyMappingManager {
 				super.getConnection(target, exchange, callback, timeout, timeUnit);
 			}
 		};
+		proxyClient.setMaxQueueSize(100);
 		proxyClient.addHost(target);
 
 		mappings.put(mapping, proxyId);


### PR DESCRIPTION
The default value for LoadBalancingProxyClient's max queue length is 0.
As soon as the target is busy serving a request we will return a 503
rather that waiting for a target to become available.

This causes openanalytics/shinyproxy#65.

This MR changes the max queue length from 0 to 100.