### PR TITLE
Fix NPE in ErrorController

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/ui/ErrorController.java
+++ b/src/main/java/eu/openanalytics/containerproxy/ui/ErrorController.java
@@ -105,7 +105,7 @@ public class ErrorController extends BaseController implements org.springframewo
 	
 	private boolean isAccountStatusException(Throwable exception) {
 		if (exception instanceof AccountStatusException) return true;
-		if (exception.getCause() != null) return isAccountStatusException(exception.getCause());
+		if (exception != null && exception.getCause() != null) return isAccountStatusException(exception.getCause());
 		return false;
 	}
 }


### PR DESCRIPTION
I frequently get NullPointerExceptions when loading the index page. I believe this happens when my authentication has timed out. The bug appears to have been introduced by [this commit](https://github.com/openanalytics/containerproxy/commit/76fe998d71859a93e2f79e27489c77b814061ff4).

I run a local build of the current develop branch + #39. Authentication is done with openid / Azure AD.

```
Error
Status code: 500

Message: An unexpected server error occurred

Stack Trace:
java.lang.NullPointerException
at eu.openanalytics.containerproxy.ui.ErrorController.isAccountStatusException(ErrorController.java:108)
at eu.openanalytics.containerproxy.ui.ErrorController.handleError(ErrorController.java:54)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:209)
...
```