### PR TITLE
Fix to return valid JWT when authenticating to Azure AD ( Microsoft Graph API implementation )

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/auth/impl/OpenIDAuthenticationBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/auth/impl/OpenIDAuthenticationBackend.java
@@ -155,11 +155,7 @@ public class OpenIDAuthenticationBackend implements IAuthenticationBackend {
 		if (auth == null) return;
 
 		OidcUser user = (OidcUser) auth.getPrincipal();
-		#HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
-		#OAuth2AuthorizedClient client = oAuth2AuthorizedClientRepository.loadAuthorizedClient(REG_ID, auth, request);
-		#if (client == null || client.getAccessToken() == null) return;
-		
-		env.add(ENV_TOKEN_NAME + "=" + user.getIdToken().getTokenValue();
+		env.add(ENV_TOKEN_NAME + "=" + user.getIdToken().getTokenValue());
 	}
 	
 	protected ClientRegistrationRepository createClientRepo() {


### PR DESCRIPTION
This will fix issue https://github.com/openanalytics/containerproxy/issues/59

Tested in with Azure AD and returns valid JWT as expected that can be used further.  Pretty much based on https://stackoverflow.com/questions/51643956/spring-security-oauth2-client-how-does-one-obtain-a-jwt-token.

Assuming will also work the same for other OpenID providers but can't test.