### PR TITLE
Adds option proxy.openid.userinfo-endpoint

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/auth/impl/OpenIDAuthenticationBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/auth/impl/OpenIDAuthenticationBackend.java
@@ -193,6 +193,7 @@ public class OpenIDAuthenticationBackend implements IAuthenticationBackend {
 				.jwkSetUri(environment.getProperty("proxy.openid.jwks-url"))
 				.clientId(environment.getProperty("proxy.openid.client-id"))
 				.clientSecret(environment.getProperty("proxy.openid.client-secret"))
+				.userInfoUri(environment.getProperty("proxy.openid.userinfo-endpoint"))
 				.build();
 		
 		return new InMemoryClientRegistrationRepository(Collections.singletonList(client));


### PR DESCRIPTION
This PR adds configuration proxy.openid.userinfo-endpoint which makes it possible to set userInfoUri(). I found this change necessary for an Identity Provider that our client uses that delivers claims through a UserInfo endpoint.