### PR TITLE
Bump spring boot starter 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.12</version>
+		<version>2.7.2</version>
 		<relativePath />
 	</parent>
 
@@ -422,7 +422,6 @@
 			<artifactId>xnio-api</artifactId>
 			<version>3.8.4.Final</version>
 		</dependency>
-
 
 
 	</dependencies>

--- a/src/main/java/eu/openanalytics/containerproxy/auth/impl/KeycloakAuthenticationBackend.java
+++ b/src/main/java/eu/openanalytics/containerproxy/auth/impl/KeycloakAuthenticationBackend.java
@@ -58,7 +58,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer.AuthorizedUrl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -87,9 +86,6 @@ public class KeycloakAuthenticationBackend implements IAuthenticationBackend {
 	@Inject
 	Environment environment;
 
-	@Inject
-	WebSecurityConfigurerAdapter webSecurityConfigurerAdapter;
-	
 	@Inject
 	ApplicationContext ctx;
 

--- a/src/main/java/eu/openanalytics/containerproxy/backend/strategy/impl/DefaultProxyLogoutStrategy.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/strategy/impl/DefaultProxyLogoutStrategy.java
@@ -37,7 +37,6 @@ public class DefaultProxyLogoutStrategy implements IProxyLogoutStrategy {
 
 	private static final String PROP_DEFAULT_STOP_PROXIES_ON_LOGOUT = "proxy.default-stop-proxy-on-logout";
 
-	@Inject
 	private ProxyService proxyService;
 
 	@Inject
@@ -52,9 +51,9 @@ public class DefaultProxyLogoutStrategy implements IProxyLogoutStrategy {
 
 	@Override
 	public void onLogout(String userId) {
-		for (Proxy proxy: proxyService.getProxies(p -> p.getUserId().equals(userId), true)) {
+		for (Proxy proxy: this.proxyService.getProxies(p -> p.getUserId().equals(userId), true)) {
 			if (shouldBeStopped(proxy)) {
-				proxyService.stopProxy(proxy, true, true);
+				this.proxyService.stopProxy(proxy, true, true);
 			}
 		}
 	}
@@ -64,6 +63,15 @@ public class DefaultProxyLogoutStrategy implements IProxyLogoutStrategy {
 			return proxy.getSpec().stopOnLogout();
 		}
 		return defaultStopProxyOnLogout;
+	}
+
+	/**
+	 * Setting ProxyService, loosing up circular dependency.
+	 *
+	 * @param proxyService proxyService.
+	 */
+	public void setProxyService(ProxyService proxyService) {
+		this.proxyService = proxyService;
 	}
 
 }

--- a/src/main/java/eu/openanalytics/containerproxy/service/UserService.java
+++ b/src/main/java/eu/openanalytics/containerproxy/service/UserService.java
@@ -74,8 +74,16 @@ public class UserService {
 	@Inject
 	private ApplicationEventPublisher applicationEventPublisher;
 
-	@Inject
 	private AccessControlService accessControlService;
+
+	/**
+	 * Setting AccessControlService, losing up circular dependencies.
+	 *
+	 * @param accessControlService accessControlService.
+	 */
+	public void setAccessControlService(AccessControlService accessControlService) {
+		this.accessControlService = accessControlService;
+	}
 
 	public Authentication getCurrentAuth() {
 		return SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/eu/openanalytics/containerproxy/util/DependencyHelper.java
+++ b/src/main/java/eu/openanalytics/containerproxy/util/DependencyHelper.java
@@ -1,0 +1,62 @@
+package eu.openanalytics.containerproxy.util;
+
+import eu.openanalytics.containerproxy.backend.strategy.impl.DefaultProxyLogoutStrategy;
+import eu.openanalytics.containerproxy.service.AccessControlService;
+import eu.openanalytics.containerproxy.service.ProxyService;
+import eu.openanalytics.containerproxy.service.UserService;
+import eu.openanalytics.containerproxy.service.hearbeat.HeartbeatService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Helper class that inject dependencies to lose up circular dependencies between beans.
+ * With refactoring this helper class might get redundant at a later stage.
+ */
+@Component
+public class DependencyHelper {
+
+    private HeartbeatService heartbeatService;
+
+    private ProxyMappingManager proxyMappingManager;
+
+    private ProxyService proxyService;
+
+    private DefaultProxyLogoutStrategy defaultProxyLogoutStrategy;
+
+    private UserService userService;
+
+    private AccessControlService accessControlService;
+
+    public DependencyHelper(
+            @Autowired HeartbeatService heartbeatService,
+            @Autowired ProxyMappingManager proxyMappingManager,
+            @Autowired ProxyService proxyService,
+            @Autowired DefaultProxyLogoutStrategy defaultProxyLogoutStrategy,
+            @Autowired UserService userService,
+            @Autowired AccessControlService accessControlService
+    ) {
+        this.heartbeatService = heartbeatService;
+        this.proxyMappingManager = proxyMappingManager;
+        this.linkBeansProxyHeartbeat();
+
+        this.proxyService = proxyService;
+        this.defaultProxyLogoutStrategy = defaultProxyLogoutStrategy;
+        this.linkBeansProxyProxyLogout();
+
+        this.userService = userService;
+        this.accessControlService = accessControlService;
+        this.linkBeansUserAccessControl();
+    }
+
+    private void linkBeansProxyHeartbeat() {
+        this.proxyMappingManager.setHeartbeatService(this.heartbeatService);
+    }
+
+    private void linkBeansProxyProxyLogout() {
+        this.defaultProxyLogoutStrategy.setProxyService(this.proxyService);
+    }
+
+    private void linkBeansUserAccessControl() {
+        this.userService.setAccessControlService(this.accessControlService);
+    }
+}

--- a/src/main/java/eu/openanalytics/containerproxy/util/ProxyMappingManager.java
+++ b/src/main/java/eu/openanalytics/containerproxy/util/ProxyMappingManager.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Inject;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -62,10 +61,18 @@ public class ProxyMappingManager {
 	private PathHandler pathHandler;
 	
 	private Map<String, String> mappings = new HashMap<>();
-	
-	@Inject
+
 	private HeartbeatService heartbeatService;
-	
+
+	/**
+	 * Setting HeartbeatService, losing up circular dependencies.
+	 *
+	 * @param heartbeatService heartbeatService.
+	 */
+	public void setHeartbeatService(HeartbeatService heartbeatService) {
+		this.heartbeatService = heartbeatService;
+	}
+
 	public synchronized HttpHandler createHttpHandler(HttpHandler defaultHandler) {
 		if (pathHandler == null) {
 			pathHandler = new ProxyPathHandler(defaultHandler);


### PR DESCRIPTION
Bump spring boot starter 2.7.2, lose up circular dependencies, remove WebSecurityConfigurerAdapter.

I've made an initial attempt to upgrade spring boot starter, partly because this is required to complete PR #69. 

Tests are passing with `mvn test -Dtest=\!TestAppRecovery,\!TestIntegrationOnKube`.