### PR TITLE
add oidc ClientAuthenticationMethod property

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/auth/impl/oidc/OpenIDConfiguration.java
+++ b/src/main/java/eu/openanalytics/containerproxy/auth/impl/oidc/OpenIDConfiguration.java
@@ -88,6 +88,7 @@ public class OpenIDConfiguration {
             .clientId(environment.getProperty("proxy.openid.client-id"))
             .clientSecret(environment.getProperty("proxy.openid.client-secret"))
             .userInfoUri(environment.getProperty("proxy.openid.userinfo-url"))
+            .clientAuthenticationMethod(environment.getProperty("proxy.openid.client-authentication-method"))
             .build();
 
         return new InMemoryClientRegistrationRepository(Collections.singletonList(client));


### PR DESCRIPTION
add OIDC ClientAuthenticationMethod property to allow the user to select different authentication method than the default method : CLIENT_SECRET_BASIC

Example : 
client-authentication-method: CLIENT_SECRET_POST

"[CLIENT_SECRET_POST](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/oauth2/core/ClientAuthenticationMethod.html#CLIENT_SECRET_POST)

