### PR TITLE
feat: add dynamic scaling for proxy sharing

### DIFF
--- a/src/main/java/eu/openanalytics/containerproxy/api/AdminController.java
+++ b/src/main/java/eu/openanalytics/containerproxy/api/AdminController.java
@@ -1,0 +1,143 @@
+/*
+ * ContainerProxy
+ *
+ * Copyright (C) 2016-2025 Open Analytics
+ *
+ * ===========================================================================
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License as published by
+ * The Apache Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License
+ * along with this program.  If not, see <http://www.apache.org/licenses/>
+ */
+package eu.openanalytics.containerproxy.api;
+
+import eu.openanalytics.containerproxy.api.dto.ApiResponse;
+import eu.openanalytics.containerproxy.backend.dispatcher.ProxyDispatcherService;
+import eu.openanalytics.containerproxy.backend.dispatcher.proxysharing.ProxySharingScaler;
+import eu.openanalytics.containerproxy.backend.dispatcher.proxysharing.ProxySharingSpecExtension;
+import eu.openanalytics.containerproxy.model.spec.ProxySpec;
+import eu.openanalytics.containerproxy.service.ProxyService;
+import eu.openanalytics.containerproxy.service.UserService;
+import org.springframework.core.env.Environment;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.inject.Inject;
+
+@RestController
+public class AdminController extends BaseController {
+
+    @Inject
+    private ProxyDispatcherService proxyDispatcherService;
+
+    @Inject
+    private ProxyService proxyService;
+
+    @Inject
+    private UserService userService;
+
+    @Inject
+    private Environment environment;
+
+    @RequestMapping(value = "/admin/app/{specId}/scale", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<ApiResponse<Void>> scaleApp(@PathVariable String specId, @RequestBody ScaleRequest request) {
+        // 1. Authentication Check
+        if (!userService.isAdmin()) {
+            return ApiResponse.failForbidden();
+        }
+
+        // 2. Get Spec & Check Configuration
+        ProxySpec spec = proxyService.getUserSpec(specId);
+        if (spec == null) {
+            return ApiResponse.fail("App not found");
+        }
+
+        ProxySharingSpecExtension ext = spec.getSpecExtension(ProxySharingSpecExtension.class);
+        if (ext == null || !ext.isAllowDynamicScaling()) {
+            return ApiResponse.fail("Dynamic scaling not allowed for this app");
+        }
+
+        // 3. Get Scaler
+        ProxySharingScaler scaler = proxyDispatcherService.getProxySharingScaler(specId);
+        if (scaler == null) {
+            return ApiResponse.fail("Scaler not found");
+        }
+
+        // 4. Validate and Apply Scale
+        Integer seats = request.getSeats();
+        if (seats == null) {
+            // Reset to config default
+            scaler.setMinimumSeatsAvailable(null);
+        } else {
+            int currentSeats = scaler.getMinimumSeatsAvailable();
+            int delta = seats - currentSeats;
+
+            // Reductions are always allowed (even if currently over-allocated)
+            if (delta < 0) {
+                scaler.setMinimumSeatsAvailable(seats);
+            } else if (delta > 0) {
+                // Validate per-app max instances
+                Integer appMaxInstances = spec.getMaxTotalInstances();
+                if (appMaxInstances > -1 && seats > appMaxInstances) {
+                    return ApiResponse.fail(
+                        "Requested seats (" + seats + ") exceed per-app maximum instances limit (" + appMaxInstances + ")"
+                    );
+                }
+
+                // Validate global capacity
+                Integer globalMaxInstances = environment.getProperty("proxy.max-total-instances", Integer.class, -1);
+                if (globalMaxInstances > -1) {
+                    int totalCurrentMinSeats = calculateTotalMinSeatsAcrossAllApps();
+                    int remainingCapacity = globalMaxInstances - totalCurrentMinSeats;
+
+                    if (delta > remainingCapacity) {
+                        return ApiResponse.fail(
+                            "Requested increase (" + delta + " seats) exceeds remaining global capacity (" + remainingCapacity + ")"
+                        );
+                    }
+                }
+
+                scaler.setMinimumSeatsAvailable(seats);
+            }
+        }
+
+        return ApiResponse.success();
+    }
+
+    private int calculateTotalMinSeatsAcrossAllApps() {
+        return proxyDispatcherService.getAllProxySharingScalers().stream()
+            .mapToInt(ProxySharingScaler::getMinimumSeatsAvailable)
+            .sum();
+    }
+
+    public static class ScaleRequest {
+        @Schema(description = "Minimum number of seats to maintain available", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Integer seats;
+
+        public Integer getSeats() {
+            return seats;
+        }
+
+        public void setSeats(Integer seats) {
+            this.seats = seats;
+        }
+    }
+}

--- a/src/main/java/eu/openanalytics/containerproxy/backend/dispatcher/ProxyDispatcherService.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/dispatcher/ProxyDispatcherService.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,7 @@ import java.util.Map;
 public class ProxyDispatcherService {
 
     private final Map<String, IProxyDispatcher> dispatchers = new HashMap<>();
+    private final Map<String, ProxySharingScaler> scalers = new HashMap<>();
     private final IProxySpecProvider proxySpecProvider;
     private final IProxySharingStoreFactory storeFactory;
     private final ConfigurableListableBeanFactory beanFactory;
@@ -68,6 +70,8 @@ public class ProxyDispatcherService {
                 createBean(proxySharingScaler, "proxySharingScaler_" + proxySpec.getId());
                 closeables.add(proxySharingScaler);
 
+                scalers.put(proxySpec.getId(), proxySharingScaler);
+
                 ProxySharingDispatcher proxySharingDispatcher = new ProxySharingDispatcher(proxySpec, delegateProxyStore, seatStore);
                 createBean(proxySharingDispatcher, "proxySharingDispatcher_" + proxySpec.getId());
 
@@ -84,6 +88,14 @@ public class ProxyDispatcherService {
 
     public IProxyDispatcher getDispatcher(String specId) {
         return dispatchers.get(specId);
+    }
+
+    public ProxySharingScaler getProxySharingScaler(String specId) {
+        return scalers.get(specId);
+    }
+
+    public Collection<ProxySharingScaler> getAllProxySharingScalers() {
+        return scalers.values();
     }
 
     private <T> void createBean(T bean, String beanName) {

--- a/src/main/java/eu/openanalytics/containerproxy/backend/dispatcher/proxysharing/ProxySharingScaler.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/dispatcher/proxysharing/ProxySharingScaler.java
@@ -103,6 +103,7 @@ public class ProxySharingScaler implements AutoCloseable {
     private boolean stopAppsOnShutdown;
     protected ReconcileStatus lastReconcileStatus = ReconcileStatus.Stable;
     private Instant lastScaleUp = null;
+    private Integer dynamicMinimumSeatsAvailable = null;
 
     @Inject
     @Lazy
@@ -144,6 +145,15 @@ public class ProxySharingScaler implements AutoCloseable {
     @PostConstruct
     public void init() {
         stopAppsOnShutdown = environment.getProperty(PROPERTY_STOP_PROXIES_ON_SHUTDOWN, Boolean.class, true);
+    }
+
+    public void setMinimumSeatsAvailable(Integer seats) {
+        this.dynamicMinimumSeatsAvailable = seats;
+        globalEventLoop.schedule(this::reconcile);
+    }
+
+    public int getMinimumSeatsAvailable() {
+        return dynamicMinimumSeatsAvailable != null ? dynamicMinimumSeatsAvailable : specExtension.minimumSeatsAvailable;
     }
 
     public static void setPublicPathPrefix(String publicPathPrefix) {
@@ -324,25 +334,28 @@ public class ProxySharingScaler implements AutoCloseable {
         }
         long numPendingSeats = getNumPendingSeats();
         long num = seatStore.getNumUnclaimedSeats() + numPendingSeats - pendingDelegatingProxies.size();
+
+        int minSeats = dynamicMinimumSeatsAvailable != null ? dynamicMinimumSeatsAvailable : specExtension.minimumSeatsAvailable;
+
         debug(String.format("Status: %s, Unclaimed: %s + PendingDelegate: %s - PendingDelegating: %s = %s -> minimum: %s",
             lastReconcileStatus, seatStore.getNumUnclaimedSeats(), numPendingSeats,
-            pendingDelegatingProxies.size(), num, specExtension.minimumSeatsAvailable));
+            pendingDelegatingProxies.size(), num, minSeats));
 
-        if (num < specExtension.minimumSeatsAvailable) {
+        if (num < minSeats) {
             if (proxySpec.getMaxTotalInstances() > -1 && seatStore.getNumSeats() >= proxySpec.getMaxTotalInstances()) {
                 logWarn(String.format("Not scaling up: currently %s seats, scale up would create more than maximum number of instances: %s", seatStore.getNumSeats(), proxySpec.getMaxTotalInstances()));
                 return;
             }
             lastReconcileStatus = ReconcileStatus.ScaleUp;
-            long numToScaleUp = specExtension.minimumSeatsAvailable - num;
+            long numToScaleUp = minSeats - num;
             scaleUp(MathUtil.divideAndCeil(numToScaleUp, specExtension.seatsPerContainer));
             lastScaleUp = Instant.now();
         } else if (numPendingSeats > 0) {
             // still scaling up
             lastReconcileStatus = ReconcileStatus.ScaleUp;
             lastScaleUp = Instant.now();
-        } else if ((num - specExtension.minimumSeatsAvailable) >= specExtension.seatsPerContainer) {
-            long numToScaleDown = (num - specExtension.minimumSeatsAvailable) / specExtension.seatsPerContainer;
+        } else if ((num - minSeats) >= specExtension.seatsPerContainer) {
+            long numToScaleDown = (num - minSeats) / specExtension.seatsPerContainer;
             if (numToScaleDown <= 0) {
                 return;
             }

--- a/src/main/java/eu/openanalytics/containerproxy/backend/dispatcher/proxysharing/ProxySharingSpecExtension.java
+++ b/src/main/java/eu/openanalytics/containerproxy/backend/dispatcher/proxysharing/ProxySharingSpecExtension.java
@@ -52,6 +52,9 @@ public class ProxySharingSpecExtension extends AbstractSpecExtension {
     @Builder.Default
     int seatsPerContainer = 1;
 
+    @Builder.Default
+    boolean allowDynamicScaling = false;
+
     @Override
     public ProxySharingSpecExtension firstResolve(SpecExpressionResolver resolver, SpecExpressionContext context) {
         return this;

--- a/src/test/java/eu/openanalytics/containerproxy/test/helpers/ShinyProxyClient.java
+++ b/src/test/java/eu/openanalytics/containerproxy/test/helpers/ShinyProxyClient.java
@@ -240,6 +240,48 @@ public class ShinyProxyClient {
         return baseUrl;
     }
 
+    public void scaleApp(String specId, int seats) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            RequestBody body = RequestBody.create(
+                objectMapper.writeValueAsString(Map.of("seats", seats)), JSON);
+            Request request = new Request.Builder()
+                .post(body)
+                .url(baseUrl + "/admin/app/" + specId + "/scale")
+                .build();
+
+            call(request, 200);
+        } catch (JsonProcessingException e) {
+            throw new TestHelperException("JSON error", e);
+        }
+    }
+
+    public JsonObject scaleAppError(String specId, int seats) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            RequestBody body = RequestBody.create(
+                objectMapper.writeValueAsString(Map.of("seats", seats)), JSON);
+            Request request = new Request.Builder()
+                .post(body)
+                .url(baseUrl + "/admin/app/" + specId + "/scale")
+                .build();
+
+            try (Response response = client.newCall(request).execute()) {
+                if (response.body() == null) {
+                    return null;
+                }
+                JsonReader jsonReader = Json.createReader(response.body().byteStream());
+                JsonObject object = jsonReader.readObject();
+                jsonReader.close();
+                return object;
+            }
+        } catch (JsonProcessingException e) {
+            throw new TestHelperException("JSON error", e);
+        } catch (Throwable t) {
+            throw new TestHelperException("Error during http request", t);
+        }
+    }
+
     public Call newCall(Request request) {
         return client.newCall(request);
     }

--- a/src/test/java/eu/openanalytics/containerproxy/test/proxy/TestIntegrationProxySharing.java
+++ b/src/test/java/eu/openanalytics/containerproxy/test/proxy/TestIntegrationProxySharing.java
@@ -40,8 +40,6 @@ import eu.openanalytics.containerproxy.test.helpers.TestProxySharingScaler;
 import eu.openanalytics.containerproxy.test.helpers.TestUtil;
 import eu.openanalytics.containerproxy.util.Retrying;
 import jakarta.json.JsonObject;
-import okhttp3.Request;
-import okhttp3.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -652,4 +650,51 @@ public class TestIntegrationProxySharing {
         Assertions.assertTrue(noPendingSeats);
     }
 
+    @ParameterizedTest
+    @MethodSource("backends")
+    public void testDynamicScaling(String backend, Map<String, String> properties) {
+        try (ContainerSetup containerSetup = new ContainerSetup(backend)) {
+            try (ShinyProxyInstance inst = new ShinyProxyInstance("application-test-dynamic-scaling.yml", properties, true)) {
+                TestProxySharingScaler proxySharingScaler = inst.getBean("proxySharingScaler_myApp", TestProxySharingScaler.class);
+                inst.enableCleanup();
+
+                // 1. Verify initial state: 1 unclaimed seat
+                waitUntilNumberOfDelegateProxies(inst, 1, 1);
+                Assertions.assertEquals(0, proxySharingScaler.getNumClaimedSeats());
+                Assertions.assertEquals(1, proxySharingScaler.getNumUnclaimedSeats());
+
+                // 2. Dynamically change minimum seats to 2
+                inst.client.scaleApp("myApp", 2);
+
+                // 3. Verify scale-up: now 2 unclaimed seats
+                waitUntilNumberOfDelegateProxies(inst, 2, 2);
+                Assertions.assertEquals(0, proxySharingScaler.getNumClaimedSeats());
+                Assertions.assertEquals(2, proxySharingScaler.getNumUnclaimedSeats());
+
+                // 4. Change back to 0 minimum seats
+                inst.client.scaleApp("myApp", 0);
+
+                // 5. Verify scale-down: back to 1 seat
+                waitUntilNumberOfDelegateProxies(inst, 1, 1);
+                Assertions.assertEquals(0, proxySharingScaler.getNumClaimedSeats());
+                Assertions.assertEquals(1, proxySharingScaler.getNumUnclaimedSeats());
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("backends")
+    public void testDynamicScalingApiNotAllowed(String backend, Map<String, String> properties) {
+        try (ContainerSetup containerSetup = new ContainerSetup(backend)) {
+            try (ShinyProxyInstance inst = new ShinyProxyInstance("application-test-pre-initialization-2.yml", properties, true)) {
+                inst.enableCleanup();
+
+                // Config has allowDynamicScaling = false (default)
+                // Try to call the scale API - should fail
+                JsonObject error = inst.client.scaleAppError("myApp", 2);
+                Assertions.assertEquals("fail", error.getString("status"));
+                Assertions.assertEquals("Dynamic scaling not allowed for this app", error.getString("data"));
+            }
+        }
+    }
 }

--- a/src/test/resources/application-test-dynamic-scaling.yml
+++ b/src/test/resources/application-test-dynamic-scaling.yml
@@ -1,0 +1,25 @@
+proxy:
+  authentication: simple
+  heartbeat-timeout: -1
+  default-stop-proxy-on-logout: false
+
+  users:
+    - name: demo
+      password: demo
+      groups:
+        - group1
+        - group2
+    - name: demo2
+      password: demo2
+
+  specs:
+    - id: myApp
+      minimum-seats-available: 1
+      allow-dynamic-scaling: true
+      scale-down-delay: 1
+      container-specs:
+        - image: "openanalytics/shinyproxy-integration-test-app"
+          cmd: [ "R", "-e", "shinyproxy::run_01_hello()" ]
+          port-mapping:
+            - name: default
+              port: 3838


### PR DESCRIPTION
- Add allowDynamicScaling boolean flag to ProxySharingSpecExtension
- Implement runtime minimumSeatsAvailable override in ProxySharingScaler
- Expose ProxySharingScaler instances via ProxyDispatcherService for API access
- Add POST /admin/app/{specId}/scale admin endpoint with JSON request body
- Add ScaleRequest DTO class with Swagger documentation
- Update ShinyProxyClient test helpers to send JSON payloads
- Add integration tests for scaling API and validation logic
- Update test configuration to enable dynamic scaling feature